### PR TITLE
Delete and Share via Bluetooth

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.seg3125.noteapp">
+
     <application
         android:allowBackup="true"
         android:name=".NoteApplication"
@@ -23,4 +24,14 @@
                 android:value=".MainActivity" />
         </activity>
     </application>
+
+    <!-- Sharing -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+
+    <!-- Bluetooth Sharing -->
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+
+
 </manifest>

--- a/app/src/main/java/com/seg3125/noteapp/EditNoteActivity.java
+++ b/app/src/main/java/com/seg3125/noteapp/EditNoteActivity.java
@@ -1,14 +1,26 @@
 package com.seg3125.noteapp;
 
+import android.bluetooth.BluetoothAdapter;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.databinding.DataBindingUtil;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.Toast;
 
 import com.seg3125.noteapp.databinding.ActivityEditNoteBinding;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.List;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.annotations.NonNull;
@@ -17,6 +29,10 @@ import io.requery.Persistable;
 import io.requery.reactivex.ReactiveEntityStore;
 
 public class EditNoteActivity extends AppCompatActivity {
+
+    // Bluetooth Sharing
+    private static final int DISCOVER_DURATION = 300;
+    private static final int REQUEST_BLU = 1;
 
     // The key used for the (optional) Note ID provided in the `Intent`.
     static final String EXTRA_NOTE_ID = "noteId";
@@ -80,9 +96,25 @@ public class EditNoteActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            // Action with ID `action_save_note` was selected
+            // Back arrow was selected
+            case android.R.id.home:
+                finish();
+                break;
+            // Action with ID 'action_save_note' was selected
             case R.id.action_save_note:
                 saveNote();
+                break;
+            // Action with ID 'action_lock_note' was selected
+            case R.id.action_lock_note:
+                lockNote();
+                break;
+            // Action with ID 'action_delete_note' was selected
+            case R.id.action_delete_note:
+                deleteNote();
+                break;
+            // Action with ID 'action_share_note' was selected from overflow menu
+            case R.id.action_share_note:
+                shareNote();
                 break;
             default:
                 break;
@@ -116,5 +148,100 @@ public class EditNoteActivity extends AppCompatActivity {
                 }
             });
         }
+    }
+
+    public void lockNote() {
+
+    }
+
+    public void deleteNote() {
+        data.delete(note).subscribe();
+        finish();
+    }
+
+    public void shareNote() {
+        sendViaBluetooth(null);
+    }
+
+    public void sendViaBluetooth(View v) {
+
+        BluetoothAdapter btAdapter = BluetoothAdapter.getDefaultAdapter();
+
+        if(btAdapter == null) {
+            Toast.makeText(this, "Bluetooth is not supported on this device", Toast.LENGTH_LONG).show();
+        } else {
+            enableBluetooth();
+        }
+    }
+
+    public void enableBluetooth() {
+
+        Intent discoveryIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
+        discoveryIntent.putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, DISCOVER_DURATION);
+        startActivityForResult(discoveryIntent, REQUEST_BLU);
+    }
+
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+
+        if(resultCode == DISCOVER_DURATION && requestCode == REQUEST_BLU) {
+
+            String filename = note.getTitle() + ".txt";
+            String string = note.getContent();
+
+            // get the path to sdcard
+            File sdcard = Environment.getExternalStorageDirectory();
+            // to this path add a new directory path
+            File dir = new File(sdcard.getAbsolutePath() + "/NoteApp/");
+            // create this directory if not already created
+            dir.mkdir();
+            Toast.makeText(this, "Dir", Toast.LENGTH_LONG).show();
+            // create the file in which we will write the contents
+            FileOutputStream os;
+
+            try {
+                File file = new File(dir, filename);
+                os = new FileOutputStream(file);
+                os.write(string.getBytes());
+                os.close();
+                Toast.makeText(this, "Note", Toast.LENGTH_LONG).show();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+            // Send the file
+            Intent intent = new Intent();
+            intent.setAction(Intent.ACTION_SEND);
+            intent.setType("text/plain");
+            File f = new File(dir, filename);
+            intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(f));
+
+            PackageManager pm = getPackageManager();
+            List<ResolveInfo> appsList = pm.queryIntentActivities(intent, 0);
+
+            if(appsList.size() > 0) {
+                String packageName = null;
+                String className = null;
+                boolean found = false;
+
+                for(ResolveInfo info : appsList) {
+                    packageName = info.activityInfo.packageName;
+                    if(packageName.equals("com.android.bluetooth")) {
+                        className = info.activityInfo.name;
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    Toast.makeText(this, "No Bluetooth devices found", Toast.LENGTH_LONG).show();
+                } else {
+                    intent.setClassName(packageName, className);
+                    startActivity(intent);
+                }
+            }
+        } else {
+            Toast.makeText(this, "Bluetooth cancelled", Toast.LENGTH_LONG).show();
+        }
+
     }
 }

--- a/app/src/main/java/com/seg3125/noteapp/MainActivity.java
+++ b/app/src/main/java/com/seg3125/noteapp/MainActivity.java
@@ -1,6 +1,10 @@
 package com.seg3125.noteapp;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
@@ -43,6 +47,9 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        // Enable permissions for writing
+        isStoragePermissionGranted();
 
         // Load the root view used by the activity.
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recyclerView);
@@ -179,6 +186,23 @@ public class MainActivity extends AppCompatActivity {
                 intent.putExtra(EditNoteActivity.EXTRA_NOTE_ID, binding.getNote().getId());
                 startActivity(intent);
             }
+        }
+    }
+
+    // Used for bluetooth sharing
+    public  boolean isStoragePermissionGranted() {
+        if (Build.VERSION.SDK_INT >= 23) {
+            if (checkSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    == PackageManager.PERMISSION_GRANTED) {
+                return true;
+            } else {
+
+                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 1);
+                return false;
+            }
+        }
+        else { //permission is automatically granted on sdk<23 upon installation
+            return true;
         }
     }
 }

--- a/app/src/main/res/drawable/ic_delete_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_delete_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lock_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_edit_note.xml
+++ b/app/src/main/res/layout/activity_edit_note.xml
@@ -7,10 +7,12 @@
             name="note"
             type="com.seg3125.noteapp.Note" />
     </data>
+
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.seg3125.noteapp.EditNoteActivity">
+
         <EditText
             android:id="@+id/titleEditText"
             android:layout_width="0dp"
@@ -27,21 +29,20 @@
             app:layout_constraintTop_toTopOf="parent"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp" />
+
         <EditText
             android:id="@+id/contentEditText"
             android:layout_width="0dp"
             android:layout_height="429dp"
-            android:layout_marginRight="0dp"
-            android:layout_marginTop="0dp"
+            android:layout_marginBottom="8dp"
             android:ems="10"
+            android:gravity="top"
             android:hint="@string/edit_note_content_hint"
             android:inputType="textMultiLine"
             android:text="@{note.content}"
-            app:layout_constraintRight_toRightOf="@+id/titleEditText"
-            app:layout_constraintTop_toBottomOf="@+id/titleEditText"
-            android:layout_marginLeft="0dp"
-            app:layout_constraintLeft_toLeftOf="@+id/titleEditText"
             app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginBottom="8dp" />
+            app:layout_constraintLeft_toLeftOf="@+id/titleEditText"
+            app:layout_constraintRight_toRightOf="@+id/titleEditText"
+            app:layout_constraintTop_toBottomOf="@+id/titleEditText" />
     </android.support.constraint.ConstraintLayout>
 </layout>

--- a/app/src/main/res/menu/edit_note_menu.xml
+++ b/app/src/main/res/menu/edit_note_menu.xml
@@ -7,4 +7,24 @@
         android:icon="@drawable/ic_save_black_24dp"
         android:title="@string/action_save_note"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_lock_note"
+        android:icon="@drawable/ic_lock_black_24dp"
+        android:title="Lock Note"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_note"
+        android:icon="@drawable/ic_delete_black_24dp"
+        android:title="Delete Note"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_share_note"
+        android:orderInCategory="100"
+        android:title="Share Note"
+        app:showAsAction="never"
+        android:visible="true" />
+
 </menu>


### PR DESCRIPTION
**NOTE**: this was written by @Ashgangabar in PR #3, but the files were in the wrong folder so I moved them to the correct folder and re-created the PR.

Add delete button.
Add lock button.
Add lock, delete, and share buttons to the `EditNoteActivity` menu bar.
Add sharing and bluetooth sharing permissions as requirements in
`AndroidManifest.xml`.
Simplify `EditNoteActivity` layout definition.
Add whitespace where necessary.
Add `DISCOVER_DURATION` and `REQUEST_BLU` constants to store bluetooth-related
configuration.
Add action handlers for the "back", "lock", "delete", and "share" actions in the
note edit menu.
Add method stubs for file sharing via bluetooth and locking notes.
Add result handler for sending bluetooth files.
Add storage permission request and check.